### PR TITLE
Adds topic support to spoilers

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from os import environ
 from urllib import urlencode
 from uuid import uuid4
 
+import re
 import porc
 import requests
 from flask import Flask, json, jsonify, redirect, request
@@ -47,7 +48,16 @@ def oauth():
 def command():
     channel = request.form['channel_id']
     user = request.form['user_id']
-    spoiler = request.form['text']
+
+    # :: attempt to parse topic
+    parse_match = r"(?:\[(?P<topic>.*)\])?\s*(?P<spoiler>.*)"
+    spoiler = parse_match.group('spoiler')
+    topic = parse_match.group('topic')
+
+    if topic is None:
+        topic = 'Spoiler alert!'
+    else:
+        topic = 'A spoiler about *{0}*!'.format(topic)
 
     token = db.get('tokens', user)['value']
 
@@ -60,7 +70,7 @@ def command():
         'as_user': True,
         'attachments': json.dumps([
             {
-                'text': 'Spoiler alert!',
+                'text': topic,
                 'fallback': 'Spoiler alert!',
                 'callback_id': callback_id,
                 'actions': [

--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ def command():
     user = request.form['user_id']
 
     # :: attempt to parse topic
-    parse_match = r"(?:\[(?P<topic>.*)\])?\s*(?P<spoiler>.*)"
+    parse_match = re.match(r"(?:\[(?P<topic>.*)\])?\s*(?P<spoiler>.*)", request.form['text'])
     spoiler = parse_match.group('spoiler')
     topic = parse_match.group('topic')
 

--- a/app.py
+++ b/app.py
@@ -73,6 +73,7 @@ def command():
                 'text': topic,
                 'fallback': 'Spoiler alert!',
                 'callback_id': callback_id,
+                'mrkdwn_in': ['text'],
                 'actions': [
                     {
                         'name': 'show_spoiler',


### PR DESCRIPTION
This allows the following format for spoiler commands:

`/command [topic] spoiler text`
e.g.
`/spoil [The Sixth Sense] Bruce Willis is dead`

The parsed topic is rendered into the initial Slack response as well:

![image](https://cloud.githubusercontent.com/assets/705310/16376162/8872fcc0-3c91-11e6-8aad-bf0a25d025b9.png)
